### PR TITLE
add typo based perturbations

### DIFF
--- a/auditor/perturbations/text.py
+++ b/auditor/perturbations/text.py
@@ -3,7 +3,6 @@ Perturbations for text inputs
 """
 import logging
 import enum
-import random
 from typing import List, Optional, Callable
 from tqdm import tqdm
 import re
@@ -259,7 +258,7 @@ class PerturbText:
 
     def perturb_typos(
             self,
-            typo_probability : float = 0.02
+            typo_probability: float = 0.02
     ) -> PerturbedTextDataset:
         """Perturb the dataset by introducing simulated user typos
 
@@ -277,7 +276,12 @@ class PerturbText:
         for sentence in self.data:
             similar_sentences = []
             for i in range(0, self.perturbations_per_sample):
-                similar_sentences.append(simulate_typos(sentence, typo_probability))
+                similar_sentences.append(
+                    simulate_typos(
+                        sentence,
+                        typo_probability
+                    )
+                )
             perturbed_dataset.append([sentence] + similar_sentences)
             total_perturbations += len(similar_sentences)
 
@@ -289,7 +293,6 @@ class PerturbText:
             perturbations_per_sample=self.perturbations_per_sample,
             perturbation_type=PerturbationType.pertrub_typos,
         )
-
 
     def paraphrase(
         self,

--- a/auditor/perturbations/text.py
+++ b/auditor/perturbations/text.py
@@ -3,6 +3,7 @@ Perturbations for text inputs
 """
 import logging
 import enum
+import random
 from typing import List, Optional, Callable
 from tqdm import tqdm
 import re
@@ -19,6 +20,8 @@ from auditor.utils.similarity import (
     load_similarity_model,
     compute_similarity
 )
+from auditor.utils.misc import simulate_typos
+
 COUNTRIES = [x.lower() for x in Perturb.data['country']]
 CITIES = [x.lower() for x in Perturb.data['city']]
 
@@ -31,6 +34,7 @@ class PerturbationType(enum.Enum):
     perturb_names = 'Names'
     perturb_location = 'Locations'
     perturb_number = 'Numbers'
+    pertrub_typos = 'Typos'
     paraphrase = 'Paraphrase'
 
     def __str__(self) -> str:
@@ -252,6 +256,40 @@ class PerturbText:
             original_dataset_size=len(self.data),
             perturbation_type=PerturbationType.perturb_number,
         )
+
+    def perturb_typos(
+            self,
+            typo_probability : float = 0.02
+    ) -> PerturbedTextDataset:
+        """Perturb the dataset by introducing simulated user typos
+
+        Args:
+            temprature: rate of errors
+
+        Returns:
+            PerturbedTextDataset: Perturbed dataset object
+        """
+
+        LOG.info("Perturbing user typos in the dataset.")
+
+        perturbed_dataset = []
+        total_perturbations = 0
+        for sentence in self.data:
+            similar_sentences = []
+            for i in range(0, self.perturbations_per_sample):
+                similar_sentences.append(simulate_typos(sentence, typo_probability))
+            perturbed_dataset.append([sentence] + similar_sentences)
+            total_perturbations += len(similar_sentences)
+
+        return PerturbedTextDataset(
+            data=perturbed_dataset,
+            metadata=None,
+            total_perturbations=total_perturbations,
+            original_dataset_size=len(self.data),
+            perturbations_per_sample=self.perturbations_per_sample,
+            perturbation_type=PerturbationType.pertrub_typos,
+        )
+
 
     def paraphrase(
         self,

--- a/auditor/utils/misc.py
+++ b/auditor/utils/misc.py
@@ -4,38 +4,38 @@ import random
 
 # nearby keys on a QWERTY keyboard
 KEYS_MAP = {
-    'a': ['q','w','s','x','z'],
-    'b': ['v','g','h','n'],
-    'c': ['x','d','f','v'],
-    'd': ['s','e','r','f','c','x'],
-    'e': ['w','s','d','r'],
-    'f': ['d','r','t','g','v','c'],
-    'g': ['f','t','y','h','b','v'],
-    'h': ['g','y','u','j','n','b'],
-    'i': ['u','j','k','o'],
-    'j': ['h','u','i','k','n','m'],
-    'k': ['j','i','o','l','m'],
-    'l': ['k','o','p'],
-    'm': ['n','j','k','l'],
-    'n': ['b','h','j','m'],
-    'o': ['i','k','l','p'],
-    'p': ['o','l'],
-    'q': ['w','a','s'],
-    'r': ['e','d','f','t'],
-    's': ['w','e','d','x','z','a'],
-    't': ['r','f','g','y'],
-    'u': ['y','h','j','i'],
-    'v': ['c','f','g','v','b'],
-    'w': ['q','a','s','e'],
-    'x': ['z','s','d','c'],
-    'y': ['t','g','h','u'],
-    'z': ['a','s','x'],
+    'a': ['q', 'w', 's', 'x', 'z'],
+    'b': ['v', 'g', 'h', 'n'],
+    'c': ['x', 'd', 'f', 'v'],
+    'd': ['s', 'e', 'r', 'f', 'c', 'x'],
+    'e': ['w', 's', 'd', 'r'],
+    'f': ['d', 'r', 't', 'g', 'v', 'c'],
+    'g': ['f', 't', 'y', 'h', 'b', 'v'],
+    'h': ['g', 'y', 'u', 'j', 'n', 'b'],
+    'i': ['u', 'j', 'k', 'o'],
+    'j': ['h', 'u', 'i', 'k', 'n', 'm'],
+    'k': ['j', 'i', 'o', 'l', 'm'],
+    'l': ['k', 'o', 'p'],
+    'm': ['n', 'j', 'k', 'l'],
+    'n': ['b', 'h', 'j', 'm'],
+    'o': ['i', 'k', 'l', 'p'],
+    'p': ['o', 'l'],
+    'q': ['w', 'a', 's'],
+    'r': ['e', 'd', 'f', 't'],
+    's': ['w', 'e', 'd', 'x', 'z', 'a'],
+    't': ['r', 'f', 'g', 'y'],
+    'u': ['y', 'h', 'j', 'i'],
+    'v': ['c', 'f', 'g', 'v', 'b'],
+    'w': ['q', 'a', 's', 'e'],
+    'x': ['z', 's', 'd', 'c'],
+    'y': ['t', 'g', 'h', 'u'],
+    'z': ['a', 's', 'x'],
 }
 
 
 def round_list(nums: List[float], precision=2):
     return [round(n, precision) for n in nums]
-    
+
 
 def simulate_typos(sentence: str, typo_probability: float) -> str:
 
@@ -58,8 +58,8 @@ def simulate_typos(sentence: str, typo_probability: float) -> str:
             typo_array = KEYS_MAP[char] + [char, None]
             typo_selection = random.choice(typo_array)
             if typo_selection is not None:
-                outputList.append(typo_selection)  
+                outputList.append(typo_selection)
         else:
-            outputList.append(char) 
+            outputList.append(char)
 
     return ''.join(outputList)

--- a/auditor/utils/misc.py
+++ b/auditor/utils/misc.py
@@ -1,6 +1,65 @@
 """For miscellaneous utilities"""
 from typing import List
+import random
+
+# nearby keys on a QWERTY keyboard
+KEYS_MAP = {
+    'a': ['q','w','s','x','z'],
+    'b': ['v','g','h','n'],
+    'c': ['x','d','f','v'],
+    'd': ['s','e','r','f','c','x'],
+    'e': ['w','s','d','r'],
+    'f': ['d','r','t','g','v','c'],
+    'g': ['f','t','y','h','b','v'],
+    'h': ['g','y','u','j','n','b'],
+    'i': ['u','j','k','o'],
+    'j': ['h','u','i','k','n','m'],
+    'k': ['j','i','o','l','m'],
+    'l': ['k','o','p'],
+    'm': ['n','j','k','l'],
+    'n': ['b','h','j','m'],
+    'o': ['i','k','l','p'],
+    'p': ['o','l'],
+    'q': ['w','a','s'],
+    'r': ['e','d','f','t'],
+    's': ['w','e','d','x','z','a'],
+    't': ['r','f','g','y'],
+    'u': ['y','h','j','i'],
+    'v': ['c','f','g','v','b'],
+    'w': ['q','a','s','e'],
+    'x': ['z','s','d','c'],
+    'y': ['t','g','h','u'],
+    'z': ['a','s','x'],
+}
 
 
 def round_list(nums: List[float], precision=2):
     return [round(n, precision) for n in nums]
+    
+
+def simulate_typos(sentence: str, typo_probability: float) -> str:
+
+    # convert the message to a list of characters
+    charList = list(sentence)
+    outputList = []
+
+    # the number of characters that will be typos
+    n_chars_to_flip = round(len(charList) * typo_probability)
+
+    # list of characters that will be flipped
+    pos_to_flip = []
+    for i in range(n_chars_to_flip):
+        pos_to_flip.append(random.randint(0, len(charList) - 1))
+
+    # insert typos
+    for pos in range(0, len(charList)):
+        char = charList[pos]
+        if pos in pos_to_flip and char in KEYS_MAP:
+            typo_array = KEYS_MAP[char] + [char, None]
+            typo_selection = random.choice(typo_array)
+            if typo_selection is not None:
+                outputList.append(typo_selection)  
+        else:
+            outputList.append(char) 
+
+    return ''.join(outputList)

--- a/auditor/utils/misc.py
+++ b/auditor/utils/misc.py
@@ -45,11 +45,11 @@ def simulate_typos(sentence: str, typo_probability: float) -> str:
     outputList = []
 
     # the positions of eligible of characters that can have typos
-    eligible_positions=[]
+    eligible_positions = []
     for pos in range(0, len(charList)):
         if charList[pos] in KEYS_MAP:
-           eligible_positions.append(pos) 
-    
+            eligible_positions.append(pos)
+
     n_chars_to_flip = math.ceil(len(charList) * typo_probability)
 
     # list of characters that will be flipped

--- a/auditor/utils/misc.py
+++ b/auditor/utils/misc.py
@@ -1,4 +1,5 @@
 """For miscellaneous utilities"""
+import math
 from typing import List
 import random
 
@@ -43,13 +44,20 @@ def simulate_typos(sentence: str, typo_probability: float) -> str:
     charList = list(sentence)
     outputList = []
 
-    # the number of characters that will be typos
-    n_chars_to_flip = round(len(charList) * typo_probability)
+    # the positions of eligible of characters that can have typos
+    eligible_positions=[]
+    for pos in range(0, len(charList)):
+        if charList[pos] in KEYS_MAP:
+           eligible_positions.append(pos) 
+    
+    n_chars_to_flip = math.ceil(len(charList) * typo_probability)
 
     # list of characters that will be flipped
     pos_to_flip = []
     for i in range(n_chars_to_flip):
-        pos_to_flip.append(random.randint(0, len(charList) - 1))
+        rand_pos = random.choice(eligible_positions)
+        pos_to_flip.append(rand_pos)
+        eligible_positions.remove(rand_pos)
 
     # insert typos
     for pos in range(0, len(charList)):

--- a/tests/test_perturbations.py
+++ b/tests/test_perturbations.py
@@ -31,6 +31,9 @@ class TestPerturbText(unittest.TestCase):
 
     def test_perturb_number(self):
         print(self.perturber.perturb_number())
+
+    def test_perturb_typos(self):
+        print(self.perturber.perturb_typos(typo_probability = 0.05))
     
     def test_paraphrase(self):
         similar_sentences = self.perturber.paraphrase(


### PR DESCRIPTION
To help users test how their model handles user typos in prompts (e.g. when sending prompts from a mobile phone), this PR introduces a mode of perturbations that simulates such typos with a simple probabilistic model based on the common keyboard layout