### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Replicate, Llama2 CodeLlama (100+LLMs) [LiteLLM]

### DIFF
--- a/auditor/generations/paraphrase.py
+++ b/auditor/generations/paraphrase.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 import os
 import openai
+import litellm
 
 from auditor.perturbations.constants import OPENAI_CHAT_COMPLETION
 
@@ -37,7 +38,7 @@ def generate_similar_sentences(
         engine = model
         api_version = api_version
 
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
       model=model,
       messages=payload,
       temperature=temperature,

--- a/auditor/perturbations/paraphrase.py
+++ b/auditor/perturbations/paraphrase.py
@@ -3,6 +3,7 @@ import os
 import re
 
 import openai
+import litellm
 
 from auditor.perturbations.base import TransformBase
 from auditor.perturbations.constants import OPENAI_CHAT_COMPLETION
@@ -73,7 +74,7 @@ class Paraphrase(TransformBase):
                 "content": prompt
             }
         ]
-        response = openai.ChatCompletion.create(
+        response = litellm.completion(
             model=self.model,
             messages=payload,
             temperature=self.temperature,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "jinja2==3.1.2",
     "langchain>=0.0.158,<=0.0.330",
     "openai>=0.27.0,<=0.28.1",
+    "litellm==0.13.2",
     "sentence-transformers>=2.2.2",
     "tqdm>=4.66.1",
     "httplib2~=0.22.0"


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```